### PR TITLE
fix overlapping of color explanation and robot logo

### DIFF
--- a/public/percent.filter.js
+++ b/public/percent.filter.js
@@ -5,6 +5,6 @@ angular.module('percent.filter', [])
 .filter('decimalToPercent', () => {
   return decimal => {
     const percent = decimal * 100;
-    return percent + '%';
+    return Math.round(percent) + '%';
   };
 });

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -55,8 +55,6 @@ input[type='text'], textarea {
 
 .logo {
   display: block;
-  height: 100px;
-  width: 100px;
   margin: 0 auto;
 }
 
@@ -136,7 +134,9 @@ input[type='text'], textarea {
 }
 
 .explanation-container > p {
+  margin: 0;
   padding: 10px 0;
+  line-height: 30px;
 }
 
 .color-key {


### PR DESCRIPTION
This Pull Request is a fix of overlapping issues on smaller window/screen sizes with both the color explanation percentages and the O3 Moods bot logo. The issue can be seen in the screenshot below. 

![screen shot 2017-01-25 at 10 24 53 am](https://cloud.githubusercontent.com/assets/25106686/22299534/72278fd2-e2f2-11e6-9cd1-375d5ce108bf.png)

In order to fix this, I took out the unnecessary width and height properties of the logo class as they are defined in the SVG.

I also adjusted the line height of the p elements in the explanation container class along with rounding any floating point percentages to the nearest integer using the round method.

The fix looks like this.

![screen shot 2017-01-25 at 11 32 48 am](https://cloud.githubusercontent.com/assets/25106686/22299666/00e433a6-e2f3-11e6-8c65-2409153ca2d6.png)

Please take a look. :)