### PR TITLE
Feature fix moodsbot SVG

### DIFF
--- a/public/svg/o3-labsbot-moods.svg
+++ b/public/svg/o3-labsbot-moods.svg
@@ -2,12 +2,6 @@
 <!-- Generator: Adobe Illustrator 21.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg  version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="150px"
 	 height="150px" viewBox="0 0 600 600" enable-background="new 0 0 600 600" xml:space="preserve">
-<g id="BG_Red" display="none">
-	<rect display="inline" fill="#CC0000" width="600" height="600"/>
-</g>
-<g id="BG_Black" display="none">
-	<rect display="inline" width="600" height="600"/>
-</g>
 <g id="O3_Labs_Bot_-_Moods">
 	<g>
 		<g>


### PR DESCRIPTION
The purpose of this PR is to take out all of the extra/unnecessary SVG code set to `"display=none"` in order to load a much smaller SVG file that is not thousands of lines of code.

Please take a look :)